### PR TITLE
Change kSFSDKSoqlMutatorOffset to kSFSDKSoqlMutatorGroupBy

### DIFF
--- a/libs/MobileSync/MobileSync/Classes/Util/SFSDKSoqlMutator.m
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFSDKSoqlMutator.m
@@ -140,7 +140,7 @@ static NSString * const kSFSDKSoqlMutatorOffset = @"offset";
                                      from:[self trimmedClause:kSFSDKSoqlMutatorFrom]]
                                     whereClause:[self trimmedClause:kSFSDKSoqlMutatorWhere]]
                                    having:[self trimmedClause:kSFSDKSoqlMutatorHaving]]
-                                  groupBy:[self trimmedClause:kSFSDKSoqlMutatorOffset]]
+                                  groupBy:[self trimmedClause:kSFSDKSoqlMutatorGroupBy]]
                                  orderBy:[self trimmedClause:kSFSDKSoqlMutatorOrderBy]];
     
     NSNumber* limit = [self clauseAsInteger:kSFSDKSoqlMutatorLimit];


### PR DESCRIPTION
Fixes #3261 . Would be nice to see it in the next 8.3 release